### PR TITLE
fix: use `isCoreCommitter` instead of `isCommitter` to be compatible with the committers who are hiding their membership in organization.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = app => {
     });
 
     app.on('issues.labeled', async context => {
-        var replaceAt = function (comment) {
+        const replaceAt = function (comment) {
             return replaceAll(
                 comment,
                 'AT_ISSUE_AUTHOR',
@@ -74,7 +74,7 @@ module.exports = app => {
         const isCommenterAuthor = commenter === context.payload.issue.user.login;
         let removeLabel;
         let addLabel;
-        if (isCommitter(context.payload.comment.author_association)) {
+        if (isCoreCommitter(commenter)) {
             // New comment from core committers
             removeLabel = getRemoveLabel(context, 'waiting-for: community');
         }
@@ -89,7 +89,6 @@ module.exports = app => {
     });
 
     app.on(['pull_request.opened'], async context => {
-        // const auth = context.payload.pull_request.author_association;
         const isCore = isCoreCommitter(context.payload.pull_request.user.login);
         const comment = context.github.issues.createComment(context.issue({
             body: isCore ? text.PR_OPENED_BY_COMMITTER : text.PR_OPENED
@@ -131,7 +130,7 @@ module.exports = app => {
 
     app.on(['pull_request_review.submitted'], async context => {
         if (context.payload.review.state === 'changes_requested'
-            && isCommitter(context.payload.review.author_association)
+            && isCoreCommitter(context.payload.review.user.login)
         ) {
             const addLabel = context.github.issues.addLabels(context.issue({
                 labels: ['PR: revision needed']

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const Issue = require('./src/issue');
 const text = require('./src/text');
-const isCoreCommitter = require('./src/coreCommitters');
+const { isCoreCommitter } = require('./src/coreCommitters');
 
 module.exports = app => {
     app.on(['issues.opened'], async context => {
@@ -157,7 +157,7 @@ function getRemoveLabel(context, name) {
 }
 
 function closeIssue(context) {
-    const closeIssue = context.github.issues.edit(context.issue({
+    const closeIssue = context.github.issues.update(context.issue({
         state: 'closed'
     }));
     return closeIssue;

--- a/src/text.js
+++ b/src/text.js
@@ -7,9 +7,9 @@ If you think you have already made your point clear without the template, or you
 
 这个 issue 未使用 [issue 模板](https://ecomfe.github.io/echarts-issue-helper/?lang=zh-cn) 创建，所以我将关闭此 issue。
 为此带来的麻烦我深表歉意，但是请理解这是为了节约社区维护者的时间，以更高效地服务社区的开发者群体。
-如果您愿意，可以请使用 issue 模板重新创建 issue。
+如果您愿意，请使用 issue 模板重新创建 issue。
 
-如果你认为虽然没有使用模板，但你已经提供了复现问题的充分描述，或者你的问题无法使用模板表达，也可以重新 open 这个 issue。`;
+如果您认为虽然没有使用模板，但您已经提供了复现问题的充分描述，或者您的问题无法使用模板表达，也可以重新 open 这个 issue。`;
 
 const ISSUE_CREATED =
     `Hi! We\'ve received your issue and please be patient to get responded. 🎉
@@ -19,7 +19,7 @@ In the meanwhile, please make sure that **you have posted enough image to demo y
 
 If you don't get helped for a long time (over a week) or have an urgent question to ask, you may also send an email to dev@echarts.apache.org. Please attach the issue link if it's a technical questions.
 
-If you are interested in the project, you may also subscribe our [mail list](https://echarts.apache.org/en/maillist.html).
+If you are interested in the project, you may also subscribe our [mailing list](https://echarts.apache.org/en/maillist.html).
 
 Have a nice day! 🍵`;
 


### PR DESCRIPTION
Currently, the bot won't add the label `PR: revision needed` when a committer requests changes.

I made some tests in my own repository, and the result indicates that 
there may be a flaw in the function [`isCommitter`](https://github.com/apache/incubator-echarts-bot/blob/master/index.js#L177-L179) if a committer is hiding his/her membership in the organization, 
that is, the `author_association` of this committer may be not `MEMBER` but `CONTRIBUTOR` for the other public people, so does the bot.

I'm not sure about this, since I have no private organization to check.

![Hide membership in the organization](https://user-images.githubusercontent.com/26999792/91119947-1ac1a480-e6c7-11ea-9f4d-42f3f3589daa.png)

![Show membership in the organization](https://user-images.githubusercontent.com/26999792/91119949-1d23fe80-e6c7-11ea-9a5e-0d0b53421814.png)

![Show membership in the organization](https://user-images.githubusercontent.com/26999792/91120100-72f8a680-e6c7-11ea-98de-a36e29a74e3d.png)

![Organization visibility: Public](https://user-images.githubusercontent.com/26999792/91120148-928fcf00-e6c7-11ea-9000-2426f20fa940.png)

![Organization visibility: Private](https://user-images.githubusercontent.com/26999792/91120501-645ebf00-e6c8-11ea-888f-5d50aa454841.png)

![image](https://user-images.githubusercontent.com/26999792/91120548-80faf700-e6c8-11ea-82ef-0347a7607662.png)

---
Additionally, Updated some texts.
